### PR TITLE
feature: Return iOS 11 support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SnapshotSafeView",
     platforms: [
-        .iOS(.v12)
+        .iOS(.v11)
     ],
     products: [
         .library(name: "SnapshotSafeView", targets: ["SnapshotSafeView"])

--- a/Sources/SnapshotSafeView/Core/HiddenContainerRecognizer.swift
+++ b/Sources/SnapshotSafeView/Core/HiddenContainerRecognizer.swift
@@ -50,6 +50,10 @@ struct HiddenContainerRecognizer {
             return "_UITextFieldContentView"
         }
 
+        if #available(iOS 11, *) {
+            return "_UITextFieldContentView"
+        }
+
         let currentIOSVersion = (UIDevice.current.systemVersion as NSString).floatValue
         throw Error.unsupportedIosVersion(version: currentIOSVersion)
     }


### PR DESCRIPTION
## **What was done?**

- Return [iOS 11](https://github.com/Stampoo/SnapshotSafeView/commit/7046c2a9bb7c68b4f714bbf68cbef64af22f3285) support

## **What to look for?**

1. Run on device with `iOS 11`